### PR TITLE
PIZ11-fix-route-to-report-bug

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+**Ticket link:**
+<!--  Add the ticket number and a link to the ticket associated with this pull request -->
+
+**Description:**
+<!-- Describe the goals of this pull request -->
+
+**Tests:**
+<!-- Describe the tests that you have done to ensure that the code is working as expected. Screenshots or videos are also helpful. -->
+
+**Screenshot/Video:**
+<!-- Attach screenshots or videos to demonstrate the changes introduced by this pull request -->
+
+**[Optional] Notes:**
+<!-- Provide any extra context or details that might be important for the reviewer -->

--- a/app/order/order-detail.html
+++ b/app/order/order-detail.html
@@ -45,6 +45,9 @@
           <li class="nav-item">
             <a class="nav-link" href="/app/size/sizes.html">Sizes</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/app/report/report.html">Report</a>
+          </li>
         </ul>
       </nav>
     </header>


### PR DESCRIPTION
**Ticket link:**
[PIZ11](https://trello.com/c/Ksqgvgtz)

**Description:**
When I’m viewing the order details I’m unable to go to the Report section, the report option is not visible.

Requirements
Display the report option when viewing an order detail

**Screenshot/video:**
- Before:
![image](https://github.com/user-attachments/assets/32fe475b-4e77-4a2a-af7e-c994323ced0c)

- After:
![image](https://github.com/user-attachments/assets/e98cbd02-0e52-4fa3-b945-505ef5f96451)
